### PR TITLE
rename "Merge with" to "Merge into", fix https://github.com/acdh-oeaw…

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/event_create_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/event_create_generic.html
@@ -3,8 +3,8 @@
 <div class="card card-default">
                         <div class="card-heading" role="tab" id="headingOne">
                             <h4 class="card-title">
-                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                                    Merge with
+                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" title="Deletes the current entity and writes labels, names, relations into the entity selected below">
+                                    Merge into
                                 </a>
                             </h4>
                         </div>

--- a/apis_core/apis_entities/templates/apis_entities/institution_create_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/institution_create_generic.html
@@ -6,8 +6,8 @@
 <div class="card card-default">
                         <div class="card-heading" role="tab" id="headingOne">
                             <h4 class="card-title">
-                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                                    Merge with
+                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" title="Deletes the current entity and writes labels, names, relations into the entity selected below">
+                                    Merge into
                                 </a>
                             </h4>
                         </div>

--- a/apis_core/apis_entities/templates/apis_entities/person_create_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/person_create_generic.html
@@ -3,8 +3,8 @@
 <div class="card card-default">
                         <div class="card-heading" role="tab" id="headingOne">
                             <h4 class="card-title">
-                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                                    Merge with
+                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" title="Deletes the current entity and writes labels, names, relations into the entity selected below">
+                                    Merge into
                                 </a>
                             </h4>
                         </div>

--- a/apis_core/apis_entities/templates/apis_entities/place_create_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/place_create_generic.html
@@ -16,8 +16,8 @@
     <div class="card card-default">
         <div class="card-heading" role="tab" id="headingOne">
             <h4 class="card-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                    Merge with
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" title="Deletes the current entity and writes labels, names, relations into the entity selected below">
+                    Merge into
                 </a>
             </h4>
         </div>

--- a/apis_core/apis_entities/templates/apis_entities/work_create_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/work_create_generic.html
@@ -3,8 +3,8 @@
 <div class="card card-default">
                         <div class="card-heading" role="tab" id="headingOne">
                             <h4 class="card-title">
-                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                                    Merge with
+                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" title="Deletes the current entity and writes labels, names, relations into the entity selected below">
+                                    Merge into
                                 </a>
                             </h4>
                         </div>

--- a/apis_core/helper_functions/RDFParser.py
+++ b/apis_core/helper_functions/RDFParser.py
@@ -308,7 +308,7 @@ class RDFParser(object):
 
     def merge(self, m_obj, app_label_relations='apis_relations'):
         """
-        :param m_obj: the object to merge with (must be an django model object instance)
+        :param m_obj: the object to merge into (must be an django model object instance)
         :param app_label_relations: (string) the label of the Django app that contains the relations
         :return: django object saved to db or False if nothing was saved
         """

--- a/apis_core/helper_functions/RDFparsers_bak.py
+++ b/apis_core/helper_functions/RDFparsers_bak.py
@@ -80,7 +80,7 @@ class GenericRDFParser(object):
 
     def merge(self, m_obj, app_label_relations='apis_relations'):
         """
-        :param m_obj: the object to merge with (must be an django model object instance)
+        :param m_obj: the object to merge into (must be an django model object instance)
         :param app_label_relations: (string) the label of the Django app that contains the relations
         :return: django object saved to db or False if nothing was saved
         """

--- a/docs/_build/html/_modules/apis_core/helper_functions/RDFParser.html
+++ b/docs/_build/html/_modules/apis_core/helper_functions/RDFParser.html
@@ -473,7 +473,7 @@
 
 <div class="viewcode-block" id="RDFParser.merge"><a class="viewcode-back" href="../../../modules/helper_functions.html#apis_core.helper_functions.RDFParser.RDFParser.merge">[docs]</a>    <span class="k">def</span> <span class="nf">merge</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">m_obj</span><span class="p">,</span> <span class="n">app_label_relations</span><span class="o">=</span><span class="s1">&#39;apis_relations&#39;</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        :param m_obj: the object to merge with (must be an django model object instance)</span>
+<span class="sd">        :param m_obj: the object to merge into (must be an django model object instance)</span>
 <span class="sd">        :param app_label_relations: (string) the label of the Django app that contains the relations</span>
 <span class="sd">        :return: django object saved to db or False if nothing was saved</span>
 <span class="sd">        &quot;&quot;&quot;</span>

--- a/docs/_build/html/modules/helper_functions.html
+++ b/docs/_build/html/modules/helper_functions.html
@@ -214,7 +214,7 @@ Stores the object in self.objct
 <dd><dl class="field-list simple">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>m_obj</strong> – the object to merge with (must be an django model object instance)</p></li>
+<li><p><strong>m_obj</strong> – the object to merge into (must be an django model object instance)</p></li>
 <li><p><strong>app_label_relations</strong> – (string) the label of the Django app that contains the relations</p></li>
 </ul>
 </dd>

--- a/docs/_modules/apis_core/helper_functions/RDFParser.html
+++ b/docs/_modules/apis_core/helper_functions/RDFParser.html
@@ -468,7 +468,7 @@
 
 <div class="viewcode-block" id="RDFParser.merge"><a class="viewcode-back" href="../../../modules/helper_functions.html#apis_core.helper_functions.RDFParser.RDFParser.merge">[docs]</a>    <span class="k">def</span> <span class="nf">merge</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">m_obj</span><span class="p">,</span> <span class="n">app_label_relations</span><span class="o">=</span><span class="s1">&#39;apis_relations&#39;</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        :param m_obj: the object to merge with (must be an django model object instance)</span>
+<span class="sd">        :param m_obj: the object to merge into (must be an django model object instance)</span>
 <span class="sd">        :param app_label_relations: (string) the label of the Django app that contains the relations</span>
 <span class="sd">        :return: django object saved to db or False if nothing was saved</span>
 <span class="sd">        &quot;&quot;&quot;</span>

--- a/docs/html/_modules/apis_core/helper_functions/RDFParser.html
+++ b/docs/html/_modules/apis_core/helper_functions/RDFParser.html
@@ -473,7 +473,7 @@
 
 <div class="viewcode-block" id="RDFParser.merge"><a class="viewcode-back" href="../../../modules/helper_functions.html#apis_core.helper_functions.RDFParser.RDFParser.merge">[docs]</a>    <span class="k">def</span> <span class="nf">merge</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">m_obj</span><span class="p">,</span> <span class="n">app_label_relations</span><span class="o">=</span><span class="s1">&#39;apis_relations&#39;</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        :param m_obj: the object to merge with (must be an django model object instance)</span>
+<span class="sd">        :param m_obj: the object to merge into (must be an django model object instance)</span>
 <span class="sd">        :param app_label_relations: (string) the label of the Django app that contains the relations</span>
 <span class="sd">        :return: django object saved to db or False if nothing was saved</span>
 <span class="sd">        &quot;&quot;&quot;</span>

--- a/docs/html/modules/helper_functions.html
+++ b/docs/html/modules/helper_functions.html
@@ -214,7 +214,7 @@ Stores the object in self.objct
 <dd><dl class="field-list simple">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>m_obj</strong> – the object to merge with (must be an django model object instance)</p></li>
+<li><p><strong>m_obj</strong> – the object to merge into (must be an django model object instance)</p></li>
 <li><p><strong>app_label_relations</strong> – (string) the label of the Django app that contains the relations</p></li>
 </ul>
 </dd>

--- a/docs/modules/helper_functions.html
+++ b/docs/modules/helper_functions.html
@@ -212,7 +212,7 @@ Stores the object in self.objct
 <dd><dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>m_obj</strong> – the object to merge with (must be an django model object instance)</p></li>
+<li><p><strong>m_obj</strong> – the object to merge into (must be an django model object instance)</p></li>
 <li><p><strong>app_label_relations</strong> – (string) the label of the Django app that contains the relations</p></li>
 </ul>
 </dd>


### PR DESCRIPTION
This is mere cosmetics, but it nevertheless creates a nuisance as the user is unsure which direction the merge has. As reverting merges is currently impossible on the frontend, it better explain what it does. Feel free to alter my suggestion... 
