### PR TITLE
Draft: add new relations behavior on deletion of related objects (#343)

### DIFF
--- a/apis_core/apis_relations/tests.py
+++ b/apis_core/apis_relations/tests.py
@@ -1,1 +1,35 @@
 # Create your tests here.
+from django.test import TestCase
+from apis_core.apis_entities.models import Person, Place
+from .models import PersonPlace
+from apis_core.apis_vocabularies.models import PersonPlaceRelation
+
+
+class RelationsTestCase(TestCase):
+    
+    @classmethod
+    def setUpTestData(cls): 
+        cls.pers1 = Person.objects.create(
+            name="Smith",
+            first_name="John",
+            start_date_written="1880<1880-02-01>",
+            end_date_written="1890<1890-05-01>",
+        )
+        cls.place1 = Place.objects.create(name="place1")
+        cls.reltype = PersonPlaceRelation.objects.create(name="Rel1", name_reverse="Rel1 reverse")
+        cls.rel = PersonPlace.objects.create(
+            related_person=cls.pers1, 
+            related_place=cls.place1, relation_type=cls.reltype)
+        cls.id_rel = cls.rel.id
+
+    def test_delete_entity(self):
+        # test that relation is deleted when entity is deleted
+        self.assertIsInstance(self.rel, PersonPlace)
+        self.place1.delete()
+        self.assertIs(PersonPlace.objects.filter(id=self.id_rel).count(), 0)
+
+    def test_delete_relation_type(self):
+        # test that relation_type is set to some default when existing relation type is deleted
+        self.assertIsInstance(self.rel, PersonPlace)
+        self.reltype.delete()
+        self.assertIs(PersonPlace.objects.filter(id=self.id_rel).count(), 1)


### PR DESCRIPTION
created a simple test that asserts that relations are deleted when entities are deleted. I think thats a foreseeable outcome (especially as the merge systematic takes care of copying relations).
However, relations are also deleted if the relation_type is deleted. And while it makes sense that a relation shouldn't exist without a relation_type I think we shouldn't delete relations when the relation type is deleted. Researchers clean up there vocabs in the admin interface and while they are warned that relations will be deleted I think we should nonetheless set the relation_type to a configurable default and keep the relation. Thus the second test is currently failing.
The behavior I suggest is:
- relations are deleted if target or source are deleted (current behaviour, tested with the new test)
- relations are rewritten to the new entity if source or target gets merged (current behavior, test needs to be extended to cover that)
- relation_types are rewritten to a default relation type if the original gets deleted (covered by the test, but current behavior is the deletion of the relation) 