### PR TITLE
Rh/hotfix/337 autocomplete endpoint should return apis

### DIFF
--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -168,9 +168,6 @@ class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
                 f = dict()
                 dataclass = ""
                 try:
-                    # The URI returned should be the APIS id, not e.g. GND
-                    # Added uri__contains filter to find APIS URI
-                    # (it *should* contain the "/entity/<id>/", unlike e.g. imported GND URI)
                     f["id"] = Uri.objects.filter(entity=r, uri__contains=f"/entity/{r.id}")[0].uri
                 except:
                     continue

--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -49,7 +49,7 @@ class CustomEntityAutocompletes(object):
         for x in func_list[entity]:
             res2 = x().query(query, page_size, offset)
             if len(res2) == page_size:
-                more[x.__name__] = (True, offset+1)
+                more[x.__name__] = (True, offset + 1)
                 more_gen = True
             res.extend(res2)
         self.results = res
@@ -68,7 +68,7 @@ class CustomEntityAutocompletes(object):
             if value[0]:
                 res3 = globals()[key](self.query, self.page_size, value[1])
                 if len(res3) == self.page_size:
-                    self._more_dict[key] = (True, value[1]+1)
+                    self._more_dict[key] = (True, value[1] + 1)
                 else:
                     self._more_dict[key] = (False, value[1])
                 self.results.extend(res3)
@@ -77,107 +77,112 @@ class CustomEntityAutocompletes(object):
 
 
 class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
-
     @staticmethod
     def parse_stanbol_object(obj, key, *args):
         if len(args) > 0:
             lst1 = args[0]
         else:
             lst1 = None
-        if obj[1] == 'GNDDate':
+        if obj[1] == "GNDDate":
             if lst1 is not None:
                 try:
-                    return dateutil.parser.parse(lst1[key][0]['value'])
+                    return dateutil.parser.parse(lst1[key][0]["value"])
                 except:
-                    return lst1[key][0]['value']
+                    return lst1[key][0]["value"]
             else:
                 return obj[0]
-        elif obj[1] == 'String':
+        elif obj[1] == "String":
             if lst1 is not None:
-                return lst1[key][0]['value']
+                return lst1[key][0]["value"]
             else:
                 return obj[0]
-        elif obj[1] == 'gndLong':
+        elif obj[1] == "gndLong":
             if lst1 is not None:
                 try:
-                    return re.search('Point \( [+-]([0-9\.]+) [+-]([0-9\.]+)', lst1[key][0]['value']).group(1)
+                    return re.search("Point \( [+-]([0-9\.]+) [+-]([0-9\.]+)", lst1[key][0]["value"]).group(1)
                 except:
-                    print('extract fails')
+                    print("extract fails")
                     return None
             else:
-                print('no match')
-
+                print("no match")
 
     def get(self, request, *args, **kwargs):
         page_size = 20
-        offset = (int(self.request.GET.get('page', 1))-1)*page_size
-        ac_type = self.kwargs['entity']
-        db_include = self.kwargs.get('db_include', False)
-        ent_merge_pk = self.kwargs.get('ent_merge_pk', False)
+        offset = (int(self.request.GET.get("page", 1)) - 1) * page_size
+        ac_type = self.kwargs["entity"]
+        db_include = self.kwargs.get("db_include", False)
+        ent_merge_pk = self.kwargs.get("ent_merge_pk", False)
         choices = []
-        headers = {'Content-Type': 'application/json'}
+        headers = {"Content-Type": "application/json"}
         ent_model = AbstractEntity.get_entity_class_of_name(ac_type)
         if not self.q:
             q3 = False
-        if self.q.startswith('http'):
+        if self.q.startswith("http"):
             res = ent_model.objects.filter(uri__uri=self.q.strip())
         elif len(self.q) > 0:
-            q1 = re.match('^([^\[]+)\[([^\]]+)\]$', self.q)
+            q1 = re.match("^([^\[]+)\[([^\]]+)\]$", self.q)
             if q1:
                 q = q1.group(1).strip()
-                q3 = q1.group(2).split(',')
+                q3 = q1.group(2).split(",")
                 q3 = [e.strip() for e in q3]
             else:
-                q = re.match('^[^\[]+', self.q).group(0)
+                q = re.match("^[^\[]+", self.q).group(0)
                 q3 = False
-            if re.match('^[^*]+\*$', q.strip()):
-                search_type = '__istartswith'
-                q = re.match('^([^*]+)\*$', q.strip()).group(1)
-            elif re.match('^\*[^*]+$', q.strip()):
-                search_type = '__iendswith'
-                q = re.match('^\*([^*]+)$', q.strip()).group(1)
-            elif re.match('^\"[^"]+\"$', q.strip()):
-                search_type = ''
-                q = re.match('^\"([^"]+)\"$', q.strip()).group(1)
-            elif re.match('^[^*]+$', q.strip()):
-                search_type = '__icontains'
+            if re.match("^[^*]+\*$", q.strip()):
+                search_type = "__istartswith"
+                q = re.match("^([^*]+)\*$", q.strip()).group(1)
+            elif re.match("^\*[^*]+$", q.strip()):
+                search_type = "__iendswith"
+                q = re.match("^\*([^*]+)$", q.strip()).group(1)
+            elif re.match('^"[^"]+"$', q.strip()):
+                search_type = ""
+                q = re.match('^"([^"]+)"$', q.strip()).group(1)
+            elif re.match("^[^*]+$", q.strip()):
+                search_type = "__icontains"
                 q = q.strip()
             else:
-                search_type = '__icontains'
+                search_type = "__icontains"
                 q = q.strip()
-            arg_list = [Q(**{x+search_type: q}) for x in settings.APIS_ENTITIES[ac_type.title()]['search']]
+            arg_list = [Q(**{x + search_type: q}) for x in settings.APIS_ENTITIES[ac_type.title()]["search"]]
             res = ent_model.objects.filter(reduce(operator.or_, arg_list)).distinct()
             if q3:
                 f_dict2 = {}
                 for fd in q3:
-                    f_dict2[fd.split('=')[0].strip()] = fd.split('=')[1].strip()
+                    f_dict2[fd.split("=")[0].strip()] = fd.split("=")[1].strip()
                 try:
                     res = res.filter(**f_dict2)
                 except Exception as e:
-                    choices.append({'name': str(e)})
+                    choices.append({"name": str(e)})
         else:
-            q = ''
+            q = ""
             res = []
         test_db = True
         test_stanbol = False
         test_stanbol_list = dict()
         more = True
         if not db_include:
-            for r in res[offset:offset+page_size]:
+            for r in res[offset : offset + page_size]:
                 if int(r.pk) == int(ent_merge_pk):
                     continue
 
                 f = dict()
                 dataclass = ""
                 try:
-                    f['id'] = Uri.objects.filter(entity=r)[0].uri
+                    # The URI returned should be the APIS id, not e.g. GND
+                    # Added uri__contains filter to find APIS URI
+                    # (it *should* contain the "/entity/<id>/", unlike e.g. imported GND URI)
+                    f["id"] = Uri.objects.filter(entity=r, uri__contains=f"/entity/{r.id}")[0].uri
                 except:
                     continue
-                if hasattr(r, 'lng'):
+                if hasattr(r, "lng"):
                     if r.lng and r.lat:
                         dataclass = 'data-vis-tooltip="{}" data-lat="{}" \
-                        data-long="{}"  class="apis-autocomplete-span"'.format(ac_type, r.lat, r.lng)
-                f['text'] = '<span {}><small>db</small> <b>{}</b> <small>db-ID: {}</small> </span> '.format(dataclass, str(r), str(r.id))
+                        data-long="{}"  class="apis-autocomplete-span"'.format(
+                            ac_type, r.lat, r.lng
+                        )
+                f["text"] = "<span {}><small>db</small> <b>{}</b> <small>db-ID: {}</small> </span> ".format(
+                    dataclass, str(r), str(r.id)
+                )
                 choices.append(f)
             if len(choices) < page_size:
                 test_db = False
@@ -186,133 +191,131 @@ class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
         if ac_type.title() in ac_settings.keys():
             for y in ac_settings[ac_type.title()]:
                 ldpath = ""
-                for d in y['fields'].keys():
-                    ldpath += "{} = <{}>;\n".format(d, y['fields'][d][0])
-                if self.q.startswith('http'):
+                for d in y["fields"].keys():
+                    ldpath += "{} = <{}>;\n".format(d, y["fields"][d][0])
+                if self.q.startswith("http"):
                     q = False
-                    match_url_geo = re.search(r'geonames[^0-9]+([0-9]+)', self.q.strip())
+                    match_url_geo = re.search(r"geonames[^0-9]+([0-9]+)", self.q.strip())
                     if match_url_geo:
-                        url = 'http://sws.geonames.org/{}/'.format(match_url_geo.group(1))
+                        url = "http://sws.geonames.org/{}/".format(match_url_geo.group(1))
                     else:
                         url = self.q.strip()
-                    params = {'id': url, 'ldpath': ldpath}
-                    headers = {'Content-Type': 'application/json'}
-                    w = requests.get(y['url'].replace('find', 'entity'), params=params, headers=headers)
+                    params = {"id": url, "ldpath": ldpath}
+                    headers = {"Content-Type": "application/json"}
+                    w = requests.get(y["url"].replace("find", "entity"), params=params, headers=headers)
                     res3 = dict()
-                    ldpath_fields = [y['fields'][d][0] for d in y['fields'].keys()]
+                    ldpath_fields = [y["fields"][d][0] for d in y["fields"].keys()]
                     print(w.status_code)
                     if w.status_code == 200:
-                        for x in w.json()['representation'].keys():
+                        for x in w.json()["representation"].keys():
                             if x in ldpath_fields:
-                                for d in y['fields'].keys():
-                                    if y['fields'][d][0] == x:
-                                        res3[d] = w.json()['representation'][x]
+                                for d in y["fields"].keys():
+                                    if y["fields"][d][0] == x:
+                                        res3[d] = w.json()["representation"][x]
                         res = dict()
-                        res3['id'] = w.json()['id']
-                        res['results'] = [res3]
+                        res3["id"] = w.json()["id"]
+                        res["results"] = [res3]
                     else:
                         continue
                 else:
 
                     data = {
-                        'limit': page_size,
-                        'ldpath': ldpath,
-                        'offset': offset,
-                        'constraints': [{
-                            "type": "text",
-                            "patternType": "wildcard",
-                            "field": "http://www.w3.org/2000/01/rdf-schema#label",
-                            "text": q.split()
-                        }]
+                        "limit": page_size,
+                        "ldpath": ldpath,
+                        "offset": offset,
+                        "constraints": [
+                            {
+                                "type": "text",
+                                "patternType": "wildcard",
+                                "field": "http://www.w3.org/2000/01/rdf-schema#label",
+                                "text": q.split(),
+                            }
+                        ],
                     }
-                    if q3 and 'search fields' in y.keys():
+                    if q3 and "search fields" in y.keys():
                         for fd in q3:
-                            fd = [fd2.strip() for fd2 in fd.split('=')]
-                            if fd[0] in y['search fields'].keys():
-                                fd3 = y['search fields'][fd[0]]
+                            fd = [fd2.strip() for fd2 in fd.split("=")]
+                            if fd[0] in y["search fields"].keys():
+                                fd3 = y["search fields"][fd[0]]
                                 v = False
                                 if isinstance(fd3[1], dict):
                                     if fd[1] in fd3[1].keys():
                                         v = fd3[1][fd[1]]
                                 else:
                                     v = fd3[1](fd[1])
-                                if fd3[2] == 'reference' and v:
+                                if fd3[2] == "reference" and v:
+                                    fd_4 = {"type": "reference", "value": v, "field": fd3[0]}
+                                    data["constraints"].append(fd_4)
+                                elif fd3[2] == "date_exact" and v:
+                                    fd_4 = {"type": "value", "value": v, "field": fd3[0], "datatype": "xsd:dateTime"}
+                                    data["constraints"].append(fd_4)
+                                elif fd3[2] == "date_gt" and v:
                                     fd_4 = {
-                                        'type': 'reference',
-                                        'value': v,
-                                        'field': fd3[0]
+                                        "type": "range",
+                                        "lowerBound": v,
+                                        "upperBound": "2100-12-31T23:59:59.999Z",
+                                        "field": fd3[0],
+                                        "datatype": "xsd:dateTime",
                                     }
-                                    data['constraints'].append(fd_4)
-                                elif fd3[2] == 'date_exact' and v:
+                                    data["constraints"].append(fd_4)
+                                elif fd3[2] == "date_lt" and v:
                                     fd_4 = {
-                                        'type': 'value',
-                                        'value': v,
-                                        'field': fd3[0],
-                                        "datatype": "xsd:dateTime"
+                                        "type": "range",
+                                        "lowerBound": "1-01-01T23:59:59.999Z",
+                                        "upperBound": v,
+                                        "field": fd3[0],
+                                        "datatype": "xsd:dateTime",
                                     }
-                                    data['constraints'].append(fd_4)
-                                elif fd3[2] == 'date_gt' and v:
-                                    fd_4 = {
-                                        'type': 'range',
-                                        'lowerBound': v,
-                                        'upperBound': "2100-12-31T23:59:59.999Z",
-                                        'field': fd3[0],
-                                        "datatype": "xsd:dateTime"
-                                    }
-                                    data['constraints'].append(fd_4)
-                                elif fd3[2] == 'date_lt' and v:
-                                    fd_4 = {
-                                        'type': 'range',
-                                        'lowerBound': "1-01-01T23:59:59.999Z",
-                                        'upperBound': v,
-                                        'field': fd3[0],
-                                        "datatype": "xsd:dateTime"
-                                    }
-                                    data['constraints'].append(fd_4)
+                                    data["constraints"].append(fd_4)
                             else:
-                                choices.append({'name': 'No additional query setting for Stanbol'})
+                                choices.append({"name": "No additional query setting for Stanbol"})
                     try:
-                        url2 = y['url'].replace('find', 'query')
+                        url2 = y["url"].replace("find", "query")
                         r = requests.post(url2, data=json.dumps(data), headers=headers)
                         if r.status_code != 200:
-                            choices.append({'name': 'Connection to Stanbol failed'})
+                            choices.append({"name": "Connection to Stanbol failed"})
                             continue
                         res = r.json()
                     except Exception as e:
-                        choices.append({'name': 'Connection to Stanbol failed'})
+                        choices.append({"name": "Connection to Stanbol failed"})
                         print(e)
                         continue
-                if len(res['results']) < page_size:
-                    test_stanbol_list[y['url']] = False
+                if len(res["results"]) < page_size:
+                    test_stanbol_list[y["url"]] = False
                 else:
-                    test_stanbol_list[y['url']] = True
-                for x in res['results']:
+                    test_stanbol_list[y["url"]] = True
+                for x in res["results"]:
                     f = dict()
                     dataclass = ""
-                    name = x['name'][0]['value']
-                    if ac_settings['score'] in x.keys():
-                        score = str(x[ac_settings['score']][0]['value'])
+                    name = x["name"][0]["value"]
+                    if ac_settings["score"] in x.keys():
+                        score = str(x[ac_settings["score"]][0]["value"])
                     else:
-                        score = 'NA'
-                    id = x[ac_settings['uri']]
+                        score = "NA"
+                    id = x[ac_settings["uri"]]
                     score = score
-                    f['id'] = id
+                    f["id"] = id
 
                     if id.endswith("/"):
                         res_id = id.split("/")[-2]
                     else:
                         res_id = id.split("/")[-1]
-                    source = y['source']
-                    if 'lat' in x.keys() and 'long' in x.keys():
+                    source = y["source"]
+                    if "lat" in x.keys() and "long" in x.keys():
                         dataclass = 'data-vis-tooltip="{}" \
                         data-lat="{}" data-long="{}"'.format(
-                            ac_type, x['lat'][0]['value'], x['long'][0]['value'])
-                    if 'descr' in x.keys():
-                        descr = x['descr'][0]['value']
+                            ac_type, x["lat"][0]["value"], x["long"][0]["value"]
+                        )
+                    if "descr" in x.keys():
+                        descr = x["descr"][0]["value"]
                     else:
                         descr = None
-                    f['text'] = '<span {} class="apis-autocomplete-span"><small>{}</small> <b>{}</b>\
-                    <small>{}-ID: {}</small> <small>info: {}</small></span>'.format(dataclass, source, name, source, res_id, descr)
+                    f[
+                        "text"
+                    ] = '<span {} class="apis-autocomplete-span"><small>{}</small> <b>{}</b>\
+                    <small>{}-ID: {}</small> <small>info: {}</small></span>'.format(
+                        dataclass, source, name, source, res_id, descr
+                    )
                     choices.append(f)
             for k in test_stanbol_list.keys():
                 if test_stanbol_list[k]:
@@ -329,77 +332,73 @@ class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
         if not test_db and not test_stanbol and not cust_auto_more:
             more = False
 
-        return http.HttpResponse(json.dumps({
-            'results': choices + [],
-            'pagination': {'more': more}
-        }), content_type='application/json')
+        return http.HttpResponse(
+            json.dumps({"results": choices + [], "pagination": {"more": more}}), content_type="application/json"
+        )
 
 
 class GenericVocabulariesAutocomplete(autocomplete.Select2ListView):
     def get(self, request, *args, **kwargs):
         page_size = 20
-        offset = (int(self.request.GET.get('page', 1))-1)*page_size
+        offset = (int(self.request.GET.get("page", 1)) - 1) * page_size
         more = False
-        vocab = self.kwargs['vocab']
-        direct = self.kwargs['direct']
+        vocab = self.kwargs["vocab"]
+        direct = self.kwargs["direct"]
         q = self.q
-        vocab_model = ContentType.objects.get(app_label='apis_vocabularies', model=vocab).model_class()
-        if direct == 'normal':
+        vocab_model = ContentType.objects.get(app_label="apis_vocabularies", model=vocab).model_class()
+        if direct == "normal":
             if vocab_model.__bases__[0] == VocabsBaseClass:
-                choices = [{'id': x.pk, 'text': x.label} for x in vocab_model.objects.filter(name__icontains=q).order_by('parent_class__name', 'name')[offset:offset+page_size]]
+                choices = [
+                    {"id": x.pk, "text": x.label}
+                    for x in vocab_model.objects.filter(name__icontains=q).order_by("parent_class__name", "name")[
+                        offset : offset + page_size
+                    ]
+                ]
             else:
-                choices = [{'id': x.pk, 'text': x.label} for x in vocab_model.objects.filter(
-                    Q(name__icontains=q) | Q(name_reverse__icontains=q)).order_by('parent_class__name', 'name')[offset:offset+page_size]]
-        elif direct == 'reverse':
-            choices = [{'id': x.pk, 'text': x.label_reverse} for x in vocab_model.objects.filter(
-                Q(name__icontains=q) | Q(name_reverse__icontains=q)).order_by('parent_class__name', 'name')[offset:offset+page_size]]
+                choices = [
+                    {"id": x.pk, "text": x.label}
+                    for x in vocab_model.objects.filter(Q(name__icontains=q) | Q(name_reverse__icontains=q)).order_by(
+                        "parent_class__name", "name"
+                    )[offset : offset + page_size]
+                ]
+        elif direct == "reverse":
+            choices = [
+                {"id": x.pk, "text": x.label_reverse}
+                for x in vocab_model.objects.filter(Q(name__icontains=q) | Q(name_reverse__icontains=q)).order_by(
+                    "parent_class__name", "name"
+                )[offset : offset + page_size]
+            ]
         if len(choices) == page_size:
             more = True
-        return http.HttpResponse(json.dumps({
-            'results': choices + [],
-            'pagination': {'more': more}
-        }), content_type='application/json')
+        return http.HttpResponse(
+            json.dumps({"results": choices + [], "pagination": {"more": more}}), content_type="application/json"
+        )
 
 
 class GenericNetworkEntitiesAutocomplete(autocomplete.Select2ListView):
     def get(self, request, *args, **kwargs):
         page_size = 20
-        offset = (int(self.request.GET.get('page', 1))-1)*page_size
+        offset = (int(self.request.GET.get("page", 1)) - 1) * page_size
         more = False
-        entity = self.kwargs['entity']
+        entity = self.kwargs["entity"]
         q = self.q
-        if q.startswith('cl:'):
+        if q.startswith("cl:"):
             res = Collection.objects.filter(name__icontains=q[3:])
-            results = [{'id': 'cl:'+str(x.pk), 'text': x.name} for x in res]
+            results = [{"id": "cl:" + str(x.pk), "text": x.name} for x in res]
         else:
-            ent_model = ContentType.objects.get(
-                app_label__startswith='apis_', model=entity
-            ).model_class()
+            ent_model = ContentType.objects.get(app_label__startswith="apis_", model=entity).model_class()
             try:
-                arg_list = [
-                    Q(
-                        **{x + '__icontains': q}
-                    ) for x in settings.APIS_ENTITIES[entity.title()]['search']
-                ]
+                arg_list = [Q(**{x + "__icontains": q}) for x in settings.APIS_ENTITIES[entity.title()]["search"]]
             except KeyError:
-                arg_list = [
-                    Q(
-                        **{x + '__icontains': q}
-                    ) for x in ['name']
-                ]
+                arg_list = [Q(**{x + "__icontains": q}) for x in ["name"]]
             try:
-                res = ent_model.objects.filter(reduce(operator.or_, arg_list)).distinct()[offset:offset+page_size]
+                res = ent_model.objects.filter(reduce(operator.or_, arg_list)).distinct()[offset : offset + page_size]
             except FieldError:
-                arg_list = [
-                    Q(
-                        **{x + '__icontains': q}
-                    ) for x in ['text']
-                ]
-                res = ent_model.objects.filter(reduce(operator.or_, arg_list)).distinct()[offset:offset+page_size]
-            results = [{'id': x.pk, 'text': str(x)} for x in res]
+                arg_list = [Q(**{x + "__icontains": q}) for x in ["text"]]
+                res = ent_model.objects.filter(reduce(operator.or_, arg_list)).distinct()[offset : offset + page_size]
+            results = [{"id": x.pk, "text": str(x)} for x in res]
         if len(results) == page_size:
             more = True
-        return http.HttpResponse(json.dumps({
-            'results': results,
-            'pagination': {'more': more}
-        }), content_type='application/json')
+        return http.HttpResponse(
+            json.dumps({"results": results, "pagination": {"more": more}}), content_type="application/json"
+        )


### PR DESCRIPTION
Fix for #337

Added additional filter to URI lookup (`apis_entities/autocomplete3.py#171`), to ensure the selected URI contains `/entity/<entity-id>` (on the basis that this is almost certainly the APIS uri, and not e.g. GND)

[Other changes are due to Black formatting!]