### PR TITLE
#361 detail and custom TEI views check in URIS if pk does not match

### DIFF
--- a/apis_core/apis_entities/detail_views.py
+++ b/apis_core/apis_entities/detail_views.py
@@ -1,20 +1,46 @@
 from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db.models import Q
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.template.loader import select_template
 from django.views import View
 from django_tables2 import RequestConfig
 from django.urls import reverse
+from django.shortcuts import redirect
 
 from apis_core.apis_labels.models import Label
 from apis_core.apis_metainfo.models import Uri
 from apis_core.apis_relations.models import AbstractRelation
 from apis_core.apis_relations.tables import get_generic_relations_table, LabelTableBase  # , EntityDetailViewLabelTable
 from apis_core.helper_functions.utils import access_for_all
-from .models import AbstractEntity
+from .models import TempEntityClass, BASE_URI
 from .views import get_highlighted_texts
+
+
+def get_object_from_pk_or_uri(request, pk):
+    """ checks if the given pk exists, if not checks if a matching apis-default uri exists
+    and returns its entity"""
+    try:
+        instance = TempEntityClass.objects_inheritance.get_subclass(pk=pk)
+        return instance
+    except TempEntityClass.DoesNotExist:
+        domain = BASE_URI
+        new_uri = f"{domain}entity/{pk}/"
+        uri2 = Uri.objects.filter(uri=new_uri)
+        if uri2.count() == 1:
+            instance = TempEntityClass.objects_inheritance.get_subclass(
+                pk=uri2[0].entity_id
+            )
+        elif uri2.count() == 0:
+            temp_obj = get_object_or_404(Uri, uri=new_uri[:-1])
+            instance = TempEntityClass.objects_inheritance.get_subclass(
+                pk=temp_obj.entity_id
+            )
+        else:
+            raise Http404
+        return instance
+
 
 
 class GenericEntitiesDetailView(UserPassesTestMixin, View):
@@ -29,8 +55,12 @@ class GenericEntitiesDetailView(UserPassesTestMixin, View):
 
         entity = kwargs['entity'].lower()
         pk = kwargs['pk']
-        entity_model = AbstractEntity.get_entity_class_of_name(entity)
-        instance = get_object_or_404(entity_model, pk=pk)
+        instance = get_object_from_pk_or_uri(request, pk)
+        # print(instance.id, pk)
+        if f"{instance.id}" == f"{pk}":
+            pass
+        else:
+            return redirect(instance)
         relations = AbstractRelation.get_relation_classes_of_entity_name(entity_name=entity)
         side_bar = []
         for rel in relations:

--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -27,6 +27,7 @@ from apis_core.apis_vocabularies.models import (
 from apis_core.helper_functions import EntityRelationFieldGenerator
 
 BASE_URI = getattr(settings, "APIS_BASE_URI", "http://apis.info/")
+DOMAIN_DEFAULT = getattr(settings, "APIS_DEFAULT_DOMAIN", "apis default")
 
 
 class AbstractEntity(TempEntityClass):
@@ -613,7 +614,7 @@ def create_default_uri(sender, instance, **kwargs):
         uri_c = "{}{}".format(
             base1, reverse("GetEntityGenericRoot", kwargs={"pk": instance.pk}),
         )
-        uri2 = Uri(uri=uri_c, domain="apis default", entity=instance)
+        uri2 = Uri(uri=uri_c, domain=DOMAIN_DEFAULT, entity=instance)
         uri2.save()
 
 

--- a/apis_core/apis_tei/views.py
+++ b/apis_core/apis_tei/views.py
@@ -3,14 +3,15 @@ import lxml.etree as ET
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 
-from apis_core.apis_entities.models import Person, Place, Institution, Work
 from .tei_utils import get_node_from_template
 from apis_core.apis_metainfo.models import Uri
+
+from apis_core.apis_entities.detail_views import get_object_from_pk_or_uri
 
 
 def person_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Person, pk=pk)
+    res = get_object_from_pk_or_uri(request, pk)
     doc = get_node_from_template('apis_tei/person.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -18,7 +19,7 @@ def person_as_tei(request, pk):
 
 def place_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Place, pk=pk)
+    res = get_object_from_pk_or_uri(request, pk)
     doc = get_node_from_template('apis_tei/place.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -26,7 +27,7 @@ def place_as_tei(request, pk):
 
 def work_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Work, pk=pk)
+    res = get_object_from_pk_or_uri(request, pk)
     doc = get_node_from_template('apis_tei/work.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -34,7 +35,7 @@ def work_as_tei(request, pk):
 
 def org_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Institution, pk=pk)
+    res = get_object_from_pk_or_uri(request, pk)
     doc = get_node_from_template('apis_tei/org.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")


### PR DESCRIPTION
`https://pmb.acdh.oeaw.ac.at/apis/entities/entity/place/50/detail` has e.g. apis-default uris 
* https://pmb.acdh.oeaw.ac.at/entity/2316
* https://pmb.acdh.oeaw.ac.at/entity/20954
* https://pmb.acdh.oeaw.ac.at/entity/65223/

so calling e.g. `https://pmb.acdh.oeaw.ac.at/apis/entities/entity/place/65223/detail` returned a 404, with this pr

calling e.g. https://pmb.acdh.oeaw.ac.at/apis/entities/entity/place/65223/detail redirects now to https://pmb.acdh.oeaw.ac.at/apis/entities/entity/place/50/detail

the same logic is applied to custom TEI endpoints but without redirect
https://pmb.acdh.oeaw.ac.at/apis/entities/tei/place/50 works (as always)
https://pmb.acdh.oeaw.ac.at/apis/entities/tei/place/65223 (no works as well)

also the previous hard code "apis default" can now be changed in the settings file 
`DOMAIN_DEFAULT = getattr(settings, "APIS_DEFAULT_DOMAIN", "apis default")`