### PR TITLE
370 if entityid called via webbrowser it should redirect to entities detail view

### DIFF
--- a/apis_core/apis_entities/api_views.py
+++ b/apis_core/apis_entities/api_views.py
@@ -104,6 +104,12 @@ class GetEntityGeneric(GenericAPIView):
 
     def get(self, request, pk):
         ent = self.get_object(pk, request)
+        data_view = request.GET.get('data-view', False)
+        format_param = request.GET.get('format', False)
+        requested_format = request.META.get('HTTP_ACCEPT')
+        
+        if requested_format.startswith('text/html') and not data_view and not format_param:
+            return redirect(ent)
         res = EntitySerializer(ent, context={"request": request})
         return Response(res.data)
 

--- a/apis_core/apis_entities/templates/apis_entities/detail_views/entity_detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/entity_detail_generic.html
@@ -79,7 +79,7 @@
                         <div class="card-header">
                             <h3>
                                 General Info
-                                <a href="/entity/{{object.id}}">
+                                <a href="/entity/{{object.id}}/?data-view=true">
                                     <small>
                                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-database">
                                             <ellipse cx="12" cy="5" rx="9" ry="3" />

--- a/apis_core/apis_entities/templates/apis_entities/detail_views/person_detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/person_detail_generic.html
@@ -40,22 +40,6 @@
             {{ object.gender }}
           </td>
         </tr>
-        <tr>
-          <th>
-            Notes
-          </th>
-          <td>
-            {{ object.notes }}
-          </td>
-        </tr>
-        <tr>
-          <th>
-            References
-          </th>
-          <td>
-            {{ object.references }}
-          </td>
-        </tr>
         {% if object.start_date or object.end_date %}
         <tr>
             <th>


### PR DESCRIPTION
* `/entity/{id}` redirects to the entities detail view IF the ACCEPT header starts with `text/html`
* other accept headers (like those registered for the given renderers) are passed through the DRF-endpoint
* this behaviour is overriden if either a query param `data-view` or `format` is given. The `data-view` param is used in the entities detail view templates, so that a click on the data icon actually links to the DRF-View
* the `format` param is processed by DRF so it overrides the ACCEPT header rule