### PR TITLE
autocomplete endpoint raises exception if entity in database but no A…

### DIFF
--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -170,7 +170,7 @@ class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
                 try:
                     f["id"] = Uri.objects.filter(entity=r, uri__contains=f"/entity/{r.id}")[0].uri
                 except:
-                    continue
+                    raise ValueError(f'No APIS URI for <{ent_model.__name__} "{r}" id="{r.id}">')
                 if hasattr(r, "lng"):
                     if r.lng and r.lat:
                         dataclass = 'data-vis-tooltip="{}" data-lat="{}" \


### PR DESCRIPTION
autocomplete endpoint raises exception if entity in database but no APIS URI

This is caused by data being created before addition of the APIS URI of an entity to `Entity.uri_set`