### PR TITLE
fix: fixes #392

### DIFF
--- a/apis_core/apis_tei/views.py
+++ b/apis_core/apis_tei/views.py
@@ -4,12 +4,18 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 
 from .tei_utils import get_node_from_template
+
 from apis_core.apis_metainfo.models import Uri
-from apis_core.apis_entities.models import Person, Institution, Place, Work
+from apis_core.apis_entities.models import Person, Place, Institution, Work
+from apis_core.apis_entities.detail_views import get_object_from_pk_or_uri
+
 
 def person_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Person, pk=pk)
+    model = Person
+    res = get_object_from_pk_or_uri(request, pk)
+    if not isinstance(res, model):
+        return HttpResponse(f"Requested object is not an instance of {model.__name__}", content_type="text/plain")
     doc = get_node_from_template('apis_tei/person.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -17,7 +23,10 @@ def person_as_tei(request, pk):
 
 def place_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Place, pk=pk)
+    model = Place
+    res = get_object_from_pk_or_uri(request, pk)
+    if not isinstance(res, model):
+        return HttpResponse(f"Requested object is not an instance of {model.__name__}", content_type="text/plain")
     doc = get_node_from_template('apis_tei/place.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -25,7 +34,10 @@ def place_as_tei(request, pk):
 
 def work_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Work, pk=pk)
+    model = Work
+    res = get_object_from_pk_or_uri(request, pk)
+    if not isinstance(res, model):
+        return HttpResponse(f"Requested object is not an instance of {model.__name__}", content_type="text/plain")
     doc = get_node_from_template('apis_tei/work.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -33,7 +45,10 @@ def work_as_tei(request, pk):
 
 def org_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_or_404(Institution, pk=pk)
+    model = Institution
+    res = get_object_from_pk_or_uri(request, pk)
+    if not isinstance(res, model):
+        return HttpResponse(f"Requested object is not an instance of {model.__name__}", content_type="text/plain")
     doc = get_node_from_template('apis_tei/org.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")

--- a/apis_core/apis_tei/views.py
+++ b/apis_core/apis_tei/views.py
@@ -5,13 +5,11 @@ from django.shortcuts import get_object_or_404, redirect
 
 from .tei_utils import get_node_from_template
 from apis_core.apis_metainfo.models import Uri
-
-from apis_core.apis_entities.detail_views import get_object_from_pk_or_uri
-
+from apis_core.apis_entities.models import Person, Institution, Place, Work
 
 def person_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_from_pk_or_uri(request, pk)
+    res = get_object_or_404(Person, pk=pk)
     doc = get_node_from_template('apis_tei/person.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -19,7 +17,7 @@ def person_as_tei(request, pk):
 
 def place_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_from_pk_or_uri(request, pk)
+    res = get_object_or_404(Place, pk=pk)
     doc = get_node_from_template('apis_tei/place.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -27,7 +25,7 @@ def place_as_tei(request, pk):
 
 def work_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_from_pk_or_uri(request, pk)
+    res = get_object_or_404(Work, pk=pk)
     doc = get_node_from_template('apis_tei/work.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")
@@ -35,7 +33,7 @@ def work_as_tei(request, pk):
 
 def org_as_tei(request, pk):
     full = request.GET.get('full')
-    res = get_object_from_pk_or_uri(request, pk)
+    res = get_object_or_404(Institution, pk=pk)
     doc = get_node_from_template('apis_tei/org.xml', res, full=full)
     tei = ET.tostring(doc, pretty_print=True, encoding='UTF-8')
     return HttpResponse(tei, content_type="application/xml")


### PR DESCRIPTION
Replaces fetching instances
- from using get_object_from_pk_or_uri
- to using get_object_or_404

This adds an automatic check for each endpoint if requested object is indeed instance of expected entity.
Otherwise, redirects to 404 page.

Removes unused import.